### PR TITLE
Fix slow item storage

### DIFF
--- a/BIM/Functions/StorageSystem.lua
+++ b/BIM/Functions/StorageSystem.lua
@@ -133,9 +133,11 @@ function SS:storeBuffer()
         -- Fill non-full stacks
         for _, chestSlot in ipairs(chestSlots) do
             if remaining <= 0 then break end
-            local pushed = self.buffer.pushItems(chestSlot.side, slot, 64, chestSlot.slot)
-            chestSlot.count = chestSlot.count + pushed
-            remaining = remaining - pushed
+            if chestSlot.count < Vs.itemDetailsMap[itemId].maxCount then
+                local pushed = self.buffer.pushItems(chestSlot.side, slot, 64, chestSlot.slot)
+                chestSlot.count = chestSlot.count + pushed
+                remaining = remaining - pushed
+            end
         end
 
         -- Put remaining items in empty slots


### PR DESCRIPTION
Caused by trying to push items into every slot with the item not just the ones with space.